### PR TITLE
Add midpoint elements polygon

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/js/ct.js",
   "types": "./lib/js/ct.d.ts",
   "scripts": {
-    "bundle-lib": "cpx ./src/canvastools/{icons,css}/* ./lib/ && cpx ./src/canvastools/ts/*.d.ts ./lib/js/ && tsc --project ./tsconfig.bundle.json",
+    "bundle-lib": "cpx ./src/canvastools/{icons,css}/* ./lib/ && cpx ./types/*.d.ts ./lib/js/ && tsc --project ./tsconfig.bundle.json",
     "prepare": "npm run clean-dist && npm run clean-lib && npm run bundle-lib && npm run webpack-dist",
     "webpack-dist-prod": "webpack --config webpack.config.js --env.mode=prod",
     "webpack-dist-prod-min": "webpack --config webpack.config.js --env.mode=prod-min",
@@ -17,9 +17,8 @@
     "clean-dist": "del-cli ./dist/",
     "clean-lib": "del-cli ./lib/",
     "plato-report": "./node_modules/.bin/es6-plato -r -d ./plato-report lib",
-    "start": "npm run build && webpack-dev-server --config webpack.config.js --env.mode=prod",
+    "start": "webpack-dev-server --config webpack.config.js",
     "build": "npm run bundle-lib && webpack --config webpack.config.js --env.mode=prod && copyfiles -f dist/ct.js samples/shared/js/",
-    "watch": "onchange src/canvastools/ts/**/*.ts src/canvastools/css/canvastools.css -- npm run start",
     "test": "jest",
     "lint": "tslint src/**/*.ts --exclude **/*.d.ts",
     "lintfix": "tslint src/**/*.ts --exclude **/*.d.ts --fix"
@@ -53,7 +52,6 @@
     "handlebars": ">=4.5.3",
     "imports-loader": "^0.8.0",
     "jest": "^25.1.0",
-    "onchange": "^6.1.0",
     "serialize-javascript": ">=3.1.0",
     "style-loader": "^0.23.1",
     "ts-jest": "^25.2.0",

--- a/src/canvastools/css/canvastools.css
+++ b/src/canvastools/css/canvastools.css
@@ -135,6 +135,10 @@
     pointer-events: none;
 }
 
+.midpointStyle {
+    stroke-width: 2;
+}
+
 .anchorStyle {
     stroke-width: 2;
 }
@@ -184,6 +188,11 @@
     fill: var(--default-color-accent);
 }
 
+.midpointStyle {
+    stroke: none;
+    fill: none;
+}
+
 .anchorStyle {
     stroke: var(--default-color-dark);
     fill: var(--default-color-pure);
@@ -191,6 +200,11 @@
 
 .regionStyle:hover .anchorStyle {
     stroke: var(--default-color-white);
+}
+
+.regionStyle:hover .midpointStyle {
+    stroke: var(--default-color-white);
+    fill: var(--default-color-white);
 }
 
 .anchorStyle.ghost,

--- a/src/canvastools/ts/CanvasTools/Core/ConfigurationManager.ts
+++ b/src/canvastools/ts/CanvasTools/Core/ConfigurationManager.ts
@@ -1,3 +1,4 @@
 export class ConfigurationManager {
     public static isModifyRegionOnlyMode: boolean = false;
+    public static isBezierLineSegmentsEnabled: boolean = false;
 }

--- a/src/canvastools/ts/CanvasTools/Core/RegionData.ts
+++ b/src/canvastools/ts/CanvasTools/Core/RegionData.ts
@@ -145,6 +145,39 @@ export class RegionData implements IRegionData, IMovable, IResizable {
         return area;
     }
 
+    public getLineSegments(): Array<[Point2D, Point2D]> {
+        const points = this.regionPoints;
+        if (points.length < 2) {
+            return []
+        }
+        if (points.length === 2) {
+            return [[points[0], points[1]]]
+        }
+        const segments = [];
+        const pointsLength = points.length;
+        const loopLength = pointsLength - 1;
+        for (let i = 0; i < loopLength; i++) {
+            const nextPointIdx = i + 1;
+            if (nextPointIdx < pointsLength) {
+                segments.push([points[i], points[nextPointIdx]])
+            }
+        }
+        if (this.regionType == RegionDataType.Polygon) {
+            // closing line segment from last to first point
+            segments.push([points[pointsLength - 1], points[0]])
+        }
+        return segments;
+    }
+
+    public getLineMidpoints(): Point2D[] {
+        const lines = this.getLineSegments();
+        return lines.map(line => {
+            const x = line[0].x - ((line[0].x - line[1].x) / 2);
+            const y = line[0].y - ((line[0].y - line[1].y) / 2);
+            return new Point2D(x, y);
+        });
+    }
+
     /**
      * Gets the bounding box size of the region
      */

--- a/src/canvastools/ts/CanvasTools/Interface/IEventDescriptor.ts
+++ b/src/canvastools/ts/CanvasTools/Interface/IEventDescriptor.ts
@@ -3,7 +3,7 @@
  * @remarks Used as an array type to specify a collection of listeners that should
  * added to each of the elements in another array.
  */
-export interface IEventDescriptor {
+ export interface IEventDescriptor<T extends PointerEvent | MouseEvent | KeyboardEvent | WheelEvent> {
     /**
      * Event name used in the `addEventListener` method
      */
@@ -13,7 +13,7 @@ export interface IEventDescriptor {
      * Event listener passed to the `addEventListener` method
      * @param e - Event object of specified type
      */
-    listener: (e: PointerEvent | MouseEvent | KeyboardEvent | WheelEvent) => void;
+    listener: (e: T) => void;
 
     /**
      * Event broadcaster on which event listener should be subscribed
@@ -25,3 +25,10 @@ export interface IEventDescriptor {
      */
     bypass: boolean;
 }
+
+export interface IMouseEventDescriptor extends IEventDescriptor<MouseEvent> {}
+export interface IPointerEventDescriptor extends IEventDescriptor<PointerEvent> {}
+export interface IKeyboardEventDescriptor extends IEventDescriptor<KeyboardEvent> {}
+export interface IWheelEventDescriptor extends IEventDescriptor<WheelEvent> {}
+
+export type EventListeners = Array<IMouseEventDescriptor | IPointerEventDescriptor | IKeyboardEventDescriptor | IWheelEventDescriptor>;

--- a/src/canvastools/ts/CanvasTools/Region/Component/AnchorsComponent.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Component/AnchorsComponent.ts
@@ -2,7 +2,7 @@ import { Point2D } from "../../Core/Point2D";
 import { Rect } from "../../Core/Rect";
 import { RegionData } from "../../Core/RegionData";
 
-import { IEventDescriptor } from "../../Interface/IEventDescriptor";
+import { EventListeners } from "../../Interface/IEventDescriptor";
 import { ChangeEventType, IRegionCallbacks } from "../../Interface/IRegionCallbacks";
 
 import { RegionComponent } from "./RegionComponent";
@@ -302,7 +302,7 @@ export abstract class AnchorsComponent extends RegionComponent {
      * Subscribe event listeners on the ghost anchor
      */
     protected subscribeGhostToEvents() {
-        const listeners: IEventDescriptor[] = [
+        const listeners: EventListeners = [
             {
                 event: "pointerenter",
                 base: this.ghostAnchor.node,

--- a/src/canvastools/ts/CanvasTools/Region/Component/DragComponent.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Component/DragComponent.ts
@@ -4,7 +4,7 @@ import { RegionData } from "../../Core/RegionData";
 
 import { ChangeEventType, IRegionCallbacks } from "../../Interface/IRegionCallbacks";
 
-import { IEventDescriptor } from "../../Interface/IEventDescriptor";
+import { EventListeners } from "../../Interface/IEventDescriptor";
 import { RegionComponent } from "./RegionComponent";
 
 /**
@@ -49,10 +49,10 @@ export abstract class DragComponent extends RegionComponent {
     }
 
     /**
-     * Helper function to subscibe the draggable element to events.
+     * Helper function to subscribe the draggable element to events.
      */
     protected subscribeToDragEvents() {
-        const listeners: IEventDescriptor[] = [
+        const listeners: EventListeners = [
             {
                 event: "pointerenter",
                 base: this.dragNode.node,

--- a/src/canvastools/ts/CanvasTools/Region/Component/MidpointComponent.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Component/MidpointComponent.ts
@@ -1,3 +1,4 @@
+import { Point2D } from "../../Core/Point2D";
 import { Rect } from "../../Core/Rect";
 import { RegionData } from "../../Core/RegionData";
 
@@ -7,11 +8,23 @@ import { EventListeners } from "../../Interface/IEventDescriptor";
 import { RegionComponent } from "./RegionComponent";
 
 /**
- * An abstract visual component to represent a midpoint along a straight line segment.
+ * Component to represent mid-points along line segments in a region.
  */
 export abstract class MidpointComponent extends RegionComponent {
   /**
-   * Midpoint visual element.
+   * Default (visual) radius for midpoints.
+   */
+  public static DEFAULT_RADIUS: number = 6;
+
+  /**
+   * Zero-based index of active midpoint.
+   */
+  protected activeMidpointIndex: number | undefined; 
+
+  protected midpointElements: Snap.Element[];
+
+  /**
+   * Grouping element for midpoints.
    */
   protected midpointNode: Snap.Element;
 
@@ -26,29 +39,103 @@ export abstract class MidpointComponent extends RegionComponent {
     paper: Snap.Paper,
     paperRect: Rect = null,
     regionData: RegionData,
-    callbacks: IRegionCallbacks,
+    callbacks: IRegionCallbacks
   ) {
     super(paper, paperRect, regionData, callbacks);
     this.node = paper.g();
     this.node.addClass("midpointLayer");
+    this.midpointElements = [];
+    this.midpointNode = this.paper.g();
+    this.node.add(this.midpointNode);
+    const regionMidpoints = this.regionData.getLineMidpoints();
+    this.buildMidpoints(regionMidpoints);
   }
 
   /**
-   * Helper function to subscribe the clickable element to events.
+   * Helper function to create a new midpoint.
+   * @param paper - The `Snap.Paper` object to draw on.
+   * @param x - The `x`-coordinate of the midpoint.
+   * @param y - The `y`-coordinate of the midpoint.
+   * @param style - Additional css style class to be applied.
+   * @param r - The radius of the midpoint.
    */
-  protected subscribeToClickEvents() {
+  protected createMidpoint(
+    paper: Snap.Paper,
+    x: number,
+    y: number,
+    style?: string,
+    r: number = MidpointComponent.DEFAULT_RADIUS
+  ): Snap.Element {
+    const midpoint = paper.circle(x, y, r);
+    midpoint.addClass("midpointStyle");
+    if (style !== undefined && style !== "") {
+      midpoint.addClass(style);
+    }
+    return midpoint;
+  }
+
+  protected teardownMidpoints() {
+    this.midpointElements.forEach(midpointElement => {
+      midpointElement.remove();
+    });
+    this.midpointElements = [];
+  }
+
+  protected buildMidpoints(regionMidpoints: Point2D[]) {
+    this.teardownMidpoints();
+    regionMidpoints.forEach((point, index) => {
+      const midpoint = this.createMidpoint(this.paper, point.x, point.y);
+      this.midpointElements.push(midpoint);
+      this.midpointNode.add(midpoint);
+      this.subscribeMidpointToEvents(midpoint, index);
+    });
+  }
+
+  public redraw() {
+    const regionMidpoints = this.regionData.getLineMidpoints();
+    if (this.midpointElements.length !== regionMidpoints.length) {
+      // if # of midpoints has changed, rebuild them
+      window.requestAnimationFrame(() => {
+        this.buildMidpoints(regionMidpoints);
+      });
+    } else {
+      // update midpoints in place
+      window.requestAnimationFrame(() => {
+          regionMidpoints.forEach((p, index) => {
+              this.midpointElements[index].attr({
+                  cx: p.x,
+                  cy: p.y,
+              });
+          });
+      });
+    }
+  }
+
+  /**
+   * Add event listeners to a midpoint's DOM node
+   */
+  protected subscribeMidpointToEvents(midpoint: Snap.Element, index: number) {
     const listeners: EventListeners = [
       {
+        event: "pointerenter",
+        base: midpoint.node,
+        listener: (e: PointerEvent) => {
+          e.stopPropagation();
+          console.log(`Midpoint entered. Index = ${index}`);
+          this.activeMidpointIndex = index;
+        },
+        bypass: false
+      },
+      {
         event: "click",
-        base: this.midpointNode.node,
+        base: midpoint.node,
         listener: (e: MouseEvent) => {
           e.stopPropagation();
-          console.log("midpoint component click event", e);
+          console.log("Midpoint component clicked", e);
         },
         bypass: false,
       },
     ];
-
     this.subscribeToEvents(listeners);
   }
 }

--- a/src/canvastools/ts/CanvasTools/Region/Component/MidpointComponent.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Component/MidpointComponent.ts
@@ -1,0 +1,54 @@
+import { Rect } from "../../Core/Rect";
+import { RegionData } from "../../Core/RegionData";
+
+import { IRegionCallbacks } from "../../Interface/IRegionCallbacks";
+
+import { EventListeners } from "../../Interface/IEventDescriptor";
+import { RegionComponent } from "./RegionComponent";
+
+/**
+ * An abstract visual component to represent a midpoint along a straight line segment.
+ */
+export abstract class MidpointComponent extends RegionComponent {
+  /**
+   * Midpoint visual element.
+   */
+  protected midpointNode: Snap.Element;
+
+  /**
+   * Creates a new `MidpointComponent` object.
+   * @param paper - The `Snap.Paper` object to draw on.
+   * @param paperRect - The parent bounding box for created component.
+   * @param regionData - The `RegionData` object shared across components. Used also for initial setup.
+   * @param callbacks - The external callbacks collection.
+   */
+  constructor(
+    paper: Snap.Paper,
+    paperRect: Rect = null,
+    regionData: RegionData,
+    callbacks: IRegionCallbacks,
+  ) {
+    super(paper, paperRect, regionData, callbacks);
+    this.node = paper.g();
+    this.node.addClass("midpointLayer");
+  }
+
+  /**
+   * Helper function to subscribe the clickable element to events.
+   */
+  protected subscribeToClickEvents() {
+    const listeners: EventListeners = [
+      {
+        event: "click",
+        base: this.midpointNode.node,
+        listener: (e: MouseEvent) => {
+          e.stopPropagation();
+          console.log("midpoint component click event", e);
+        },
+        bypass: false,
+      },
+    ];
+
+    this.subscribeToEvents(listeners);
+  }
+}

--- a/src/canvastools/ts/CanvasTools/Region/Component/RegionComponent.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Component/RegionComponent.ts
@@ -1,13 +1,12 @@
 import { Rect } from "../../Core/Rect";
 import { RegionData } from "../../Core/RegionData";
 
-import { type } from "os";
-import { IEventDescriptor } from "../../Interface/IEventDescriptor";
+import { EventListeners } from "../../Interface/IEventDescriptor";
 import { IFreezable } from "../../Interface/IFreezable";
 import { IHideable } from "../../Interface/IHideadble";
 import { IMovable } from "../../Interface/IMovable";
 import { IPoint2D } from "../../Interface/IPoint2D";
-import { ChangeEventType, IRegionCallbacks } from "../../Interface/IRegionCallbacks";
+import { IRegionCallbacks } from "../../Interface/IRegionCallbacks";
 import { IResizable } from "../../Interface/IResizable";
 
 /**
@@ -203,14 +202,14 @@ export abstract class RegionComponent implements IHideable, IResizable, IMovable
      * Subscribes the component elements according to provided event descriptors. Binds to the `this` object.
      * @param listeners - The collection of event descriptors.
      */
-    protected subscribeToEvents(listeners: IEventDescriptor[]) {
+    protected subscribeToEvents(listeners: EventListeners) {
         listeners.forEach((e) => {
             e.base.addEventListener(e.event, this.makeFreezable(e.listener.bind(this), e.bypass));
         });
     }
 
     /**
-     * A helper function to make event listeners froozen if the component state is frozen.
+     * A helper function to make event listeners frozen if the component state is frozen.
      * @param f - Function to wrap.
      * @param bypass - A flag whether event should bypass.
      */

--- a/src/canvastools/ts/CanvasTools/Region/Polygon/AnchorsElement.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Polygon/AnchorsElement.ts
@@ -107,14 +107,14 @@ export class AnchorsElement extends AnchorsComponent {
      * Creates a collection on anchors.
      */
     protected buildAnchors() {
-        this.buildPolylineAnchors();
+        this.buildPolygonAnchors();
         super.buildAnchors();
     }
 
     /**
      * Creates a collection of anchor points.
      */
-    protected buildPolylineAnchors() {
+    protected buildPolygonAnchors() {
         const pointsData = [];
         this.regionData.points.forEach((p) => {
             pointsData.push(p.x, p.y);

--- a/src/canvastools/ts/CanvasTools/Region/Polygon/MidpointElement.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Polygon/MidpointElement.ts
@@ -1,0 +1,54 @@
+import { Point2D } from "../../Core/Point2D";
+import { Rect } from "../../Core/Rect";
+import { RegionData } from "../../Core/RegionData";
+
+import { IRegionCallbacks } from "../../Interface/IRegionCallbacks";
+
+import { MidpointComponent } from "../Component/MidpointComponent";
+
+/**
+ * `MidpointComponent` for the `PolygonRegion` class.
+ */
+export class MidpointElement extends MidpointComponent {
+    /**
+     * Default (visual) radius for point drag-component.
+     */
+    public static DEFAULT_RADIUS: number = 6;
+
+    private midpoints: Snap.Element[];
+
+    /**
+     * Creates a new `DragElement`.
+     * @param paper - The `Snap.Paper` object to draw on.
+     * @param paperRect - The parent bounding box for created component.
+     * @param regionData - The `RegionData` object shared across components. Used also for initial setup.
+     * @param callbacks - The external callbacks collection.
+     */
+    constructor(paper: Snap.Paper, paperRect: Rect = null, regionData: RegionData, callbacks: IRegionCallbacks) {
+        super(paper, paperRect, regionData, callbacks);
+
+        this.midpointNode = paper.circle(this.x, this.y, MidpointElement.DEFAULT_RADIUS);
+        this.midpointNode.addClass("midPointStyle");
+
+        this.node.add(this.midpointNode);
+
+        this.subscribeToClickEvents();
+    }
+
+    /**
+     * Redraws the component.
+     */
+    public redraw() {
+        // this.regionData.points.forEach(() )
+        // const lines = this.regionData.points.reduce<Array<[Point2D, Point2D]>>((acc, point, idx) => {
+
+        // }, []);
+        // TODO: calculate midpoints of line segments in regionData and draw elements circles
+        window.requestAnimationFrame(() => {
+            this.midpointNode.attr({
+                cx: this.x,
+                cy: this.y,
+            });
+        });
+    }
+}

--- a/src/canvastools/ts/CanvasTools/Region/Polygon/MidpointElement.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Polygon/MidpointElement.ts
@@ -1,4 +1,3 @@
-import { Point2D } from "../../Core/Point2D";
 import { Rect } from "../../Core/Rect";
 import { RegionData } from "../../Core/RegionData";
 
@@ -11,13 +10,6 @@ import { MidpointComponent } from "../Component/MidpointComponent";
  */
 export class MidpointElement extends MidpointComponent {
     /**
-     * Default (visual) radius for point drag-component.
-     */
-    public static DEFAULT_RADIUS: number = 6;
-
-    private midpoints: Snap.Element[];
-
-    /**
      * Creates a new `DragElement`.
      * @param paper - The `Snap.Paper` object to draw on.
      * @param paperRect - The parent bounding box for created component.
@@ -26,29 +18,5 @@ export class MidpointElement extends MidpointComponent {
      */
     constructor(paper: Snap.Paper, paperRect: Rect = null, regionData: RegionData, callbacks: IRegionCallbacks) {
         super(paper, paperRect, regionData, callbacks);
-
-        this.midpointNode = paper.circle(this.x, this.y, MidpointElement.DEFAULT_RADIUS);
-        this.midpointNode.addClass("midPointStyle");
-
-        this.node.add(this.midpointNode);
-
-        this.subscribeToClickEvents();
-    }
-
-    /**
-     * Redraws the component.
-     */
-    public redraw() {
-        // this.regionData.points.forEach(() )
-        // const lines = this.regionData.points.reduce<Array<[Point2D, Point2D]>>((acc, point, idx) => {
-
-        // }, []);
-        // TODO: calculate midpoints of line segments in regionData and draw elements circles
-        window.requestAnimationFrame(() => {
-            this.midpointNode.attr({
-                cx: this.x,
-                cy: this.y,
-            });
-        });
     }
 }

--- a/src/canvastools/ts/CanvasTools/Region/Polygon/PolygonRegion.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Polygon/PolygonRegion.ts
@@ -7,6 +7,7 @@ import { RegionComponent } from "../Component/RegionComponent";
 import { Region } from "../Region";
 import { AnchorsElement } from "./AnchorsElement";
 import { DragElement } from "./DragElement";
+import { MidpointElement } from "./MidpointElement";
 import { TagsElement } from "./TagsElement";
 
 /**
@@ -17,7 +18,12 @@ export class PolygonRegion extends Region {
      * Reference to the internal AnchorsElement.
      */
     private anchorNode: AnchorsElement;
-
+    
+    /**
+     * Reference to midpoint node
+     */
+    private midpointNode: MidpointElement; 
+    
     /**
      * Reference to the internal DragElement.
      */
@@ -103,6 +109,7 @@ export class PolygonRegion extends Region {
         this.tagsNode = new TagsElement(paper, this.paperRect, this.regionData, this.tags, this.styleID,
                                         this.styleSheet, this.tagsUpdateOptions);
         this.anchorNode = new AnchorsElement(paper, this.paperRect, this.regionData, this.callbacks);
+        this.midpointNode = new MidpointElement(paper, this.paperRect, this.regionData, this.callbacks);
 
         this.toolTip = Snap.parse(`<title>${(this.tags !== null) ? this.tags.toString() : ""}</title>`);
         this.node.append(this.toolTip as any);
@@ -110,7 +117,8 @@ export class PolygonRegion extends Region {
         this.node.add(this.dragNode.node);
         this.node.add(this.tagsNode.node);
         this.node.add(this.anchorNode.node);
+        this.node.add(this.midpointNode.node);
 
-        this.UI.push(this.tagsNode, this.dragNode, this.anchorNode);
+        this.UI.push(this.tagsNode, this.dragNode, this.anchorNode, this.midpointNode);
     }
 }

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/PointSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/PointSelector.ts
@@ -2,7 +2,7 @@ import { Point2D } from "../../Core/Point2D";
 import { Rect } from "../../Core/Rect";
 import { RegionData } from "../../Core/RegionData";
 
-import { IEventDescriptor } from "../../Interface/IEventDescriptor";
+import { EventListeners } from "../../Interface/IEventDescriptor";
 import { ISelectorCallbacks } from "../../Interface/ISelectorCallbacks";
 
 import { IPoint2D } from "../../Interface/IPoint2D";
@@ -88,7 +88,7 @@ export class PointSelector extends Selector {
         this.node.add(this.crossA.node);
         this.node.add(this.point);
 
-        const listeners: IEventDescriptor[] = [
+        const listeners: EventListeners = [
             {
                 event: "pointerenter",
                 base: this.parentNode,

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/PolygonSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/PolygonSelector.ts
@@ -2,7 +2,7 @@ import { Point2D } from "../../Core/Point2D";
 import { Rect } from "../../Core/Rect";
 import { RegionData, RegionDataType } from "../../Core/RegionData";
 
-import { IEventDescriptor } from "../../Interface/IEventDescriptor";
+import { EventListeners } from "../../Interface/IEventDescriptor";
 import { IMovable } from "../../Interface/IMovable";
 import { ISelectorCallbacks } from "../../Interface/ISelectorCallbacks";
 
@@ -228,7 +228,7 @@ export class PolygonSelector extends Selector {
         this.node.add(this.nextSegment);
         this.node.add(this.nextPoint);
 
-        const listeners: IEventDescriptor[] = [
+        const listeners: EventListeners = [
             {
                 event: "pointerenter",
                 base: this.parentNode,

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/PolylineSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/PolylineSelector.ts
@@ -2,7 +2,7 @@ import { Point2D } from "../../Core/Point2D";
 import { Rect } from "../../Core/Rect";
 import { RegionData, RegionDataType } from "../../Core/RegionData";
 
-import { IEventDescriptor } from "../../Interface/IEventDescriptor";
+import { EventListeners } from "../../Interface/IEventDescriptor";
 import { IMovable } from "../../Interface/IMovable";
 import { ISelectorCallbacks } from "../../Interface/ISelectorCallbacks";
 
@@ -168,7 +168,7 @@ export class PolylineSelector extends Selector {
         this.node.add(this.nextSegment);
         this.node.add(this.nextPoint);
 
-        const listeners: IEventDescriptor[] = [
+        const listeners: EventListeners = [
             { event: "pointerenter", listener: this.onPointerEnter, base: this.parentNode, bypass: false },
             { event: "pointerleave", listener: this.onPointerLeave, base: this.parentNode, bypass: false },
             { event: "pointerdown", listener: this.onPointerDown, base: this.parentNode, bypass: false },
@@ -297,6 +297,10 @@ export class PolylineSelector extends Selector {
      */
     private submitPolyline() {
         if (typeof this.callbacks.onSelectionEnd === "function") {
+            const points = this.getPolylinePoints();
+            if (points.length <= 0) {
+                return;
+            }
             const box = this.polyline.getBBox();
 
             this.callbacks.onSelectionEnd(new RegionData(box.x, box.y, box.width, box.height,

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/RectCopySelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/RectCopySelector.ts
@@ -2,7 +2,7 @@ import { Point2D } from "../../Core/Point2D";
 import { Rect } from "../../Core/Rect";
 import { RegionData } from "../../Core/RegionData";
 
-import { IEventDescriptor } from "../../Interface/IEventDescriptor";
+import { EventListeners } from "../../Interface/IEventDescriptor";
 import { IRect } from "../../Interface/IRect";
 import { ISelectorCallbacks } from "../../Interface/ISelectorCallbacks";
 
@@ -130,7 +130,7 @@ export class RectCopySelector extends Selector {
         this.node.add(this.crossA.node);
         this.node.add(this.copyRectEl.node);
 
-        const listeners: IEventDescriptor[] = [
+        const listeners: EventListeners = [
             { event: "pointerenter", listener: this.onPointerEnter, base: this.parentNode, bypass: false },
             { event: "pointerleave", listener: this.onPointerLeave, base: this.parentNode, bypass: false },
             { event: "pointerdown", listener: this.onPointerDown, base: this.parentNode, bypass: false },

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
@@ -2,7 +2,7 @@ import { Point2D } from "../../Core/Point2D";
 import { Rect } from "../../Core/Rect";
 import { RegionData } from "../../Core/RegionData";
 
-import { IEventDescriptor } from "../../Interface/IEventDescriptor";
+import { EventListeners } from "../../Interface/IEventDescriptor";
 import { ISelectorCallbacks } from "../../Interface/ISelectorCallbacks";
 
 import { IPoint2D } from "../../Interface/IPoint2D";
@@ -157,7 +157,7 @@ export class RectSelector extends Selector {
         this.node.add(this.crossB.node);
         this.node.add(this.selectionBox.node);
 
-        const listeners: IEventDescriptor[] = [
+        const listeners: EventListeners = [
             { event: "pointerenter", listener: this.onPointerEnter, base: this.parentNode, bypass: false },
             { event: "pointerleave", listener: this.onPointerLeave, base: this.parentNode, bypass: false },
             { event: "pointerdown", listener: this.onPointerDown, base: this.parentNode, bypass: false },

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/Selector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/Selector.ts
@@ -1,6 +1,6 @@
 import { Rect } from "../../Core/Rect";
 
-import { IEventDescriptor } from "../../Interface/IEventDescriptor";
+import { EventListeners } from "../../Interface/IEventDescriptor";
 import { IHideable } from "../../Interface/IHideadble";
 import { IResizable } from "../../Interface/IResizable";
 import { ISelectorCallbacks } from "../../Interface/ISelectorCallbacks";
@@ -80,7 +80,7 @@ export abstract class Selector extends Element {
      * Helper function to subscribe collection of elements to specified listeners.
      * @param listeners - The collection of `IEventDescriptor` objects.
      */
-    protected subscribeToEvents(listeners: IEventDescriptor[]) {
+    protected subscribeToEvents(listeners: EventListeners) {
         listeners.forEach((e) => {
             e.base.addEventListener(e.event, this.enablify(e.listener.bind(this), e.bypass));
         });

--- a/src/canvastools/ts/ct.ts
+++ b/src/canvastools/ts/ct.ts
@@ -19,9 +19,8 @@ import { RegionsManager } from "./CanvasTools/Region/RegionsManager";
 import { AreaSelector } from "./CanvasTools/Selection/AreaSelector";
 import { Toolbar as CTToolbar } from "./CanvasTools/Toolbar/Toolbar";
 
+// Snap adds itself to the window
 import "snapsvg-cjs";
-/* import * as SNAPSVG_TYPE from "snapsvg";
-declare var Snap: typeof SNAPSVG_TYPE; */
 
 export class CanvasTools {
     /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,11 +23,11 @@
         /* "outFile": "dist/ct.js" */
     },
     "include": [     
-        "src/canvastools/ts/*.ts",
-        "src/canvastools/ts/*.d.ts"
+        "./src/canvastools/ts/**/*.ts",
+        "./types/**/*.d.ts"
     ],
     "exclude": [     
-        "src/canvastools/ts/*spec.ts",
-        "src/canvastools/ts/*spec.js"
+        "./src/canvastools/ts/**/*.spec.ts",
+        "./src/canvastools/ts/**/*.spec.js"
     ]
 }

--- a/types/snapsvg-cjs.d.ts
+++ b/types/snapsvg-cjs.d.ts
@@ -3,14 +3,6 @@
 // Definitions by: Lars Klein <https://github.com/lhk>, Mattanja Kern <https://github.com/mattanja>, Andrey Kurdyumov <https://github.com/kant2002>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
-/* export = Snap; */
-/* export as namespace Snap; */
-
-declare module "snapsvg-cjs" {
-    export = Snap;
- }
-
 declare function Snap(width:number|string,height:number|string):Snap.Paper;
 declare function Snap(query:string):Snap.Paper;
 declare function Snap(DOM:SVGElement):Snap.Paper;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,15 +42,11 @@ var webpackSettings = {
     },
 }
 
-var settings = webpackSettings[yargs.argv.set];
-if (settings == undefined) {
-    settings = webpackSettings['dev'];
-}
-
 module.exports = function (env) {
-    var settings = webpackSettings[env.mode];
+    const mode = (env && env.mode) || "prod";
+    var settings = webpackSettings[mode];
     if (settings == undefined) {
-        settings = webpackSettings['dev'];
+        settings = webpackSettings['prod'];
     }
 
     var config = {
@@ -70,7 +66,8 @@ module.exports = function (env) {
         },
         devServer: {
             contentBase: path.join(__dirname, 'samples'),
-            port: 9000
+            port: 9000,
+            publicPath: "/shared/js/"
         },
         module: {
             rules: [


### PR DESCRIPTION
Adding midpoint elements to polygon line segments.
These midpoint elements will serve as visual cues to convert straight line segments to curved lines.

![MidpointElements](https://user-images.githubusercontent.com/89158516/141845827-432377c6-6183-41ec-b2a2-ae49b878fb76.png) 